### PR TITLE
synchronize system clock to hardware time

### DIFF
--- a/include/urg_node/urg_c_wrapper.h
+++ b/include/urg_node/urg_c_wrapper.h
@@ -89,9 +89,9 @@ public:
 class URGCWrapper
 {
 public:
-  URGCWrapper(const std::string& ip_address, const int ip_port, bool& using_intensity, bool& using_multiecho);
+  URGCWrapper(const std::string& ip_address, const int ip_port, bool& using_intensity, bool& using_multiecho, bool& synchronize_time);
 
-  URGCWrapper(const int serial_baud, const std::string& serial_port, bool& using_intensity, bool& using_multiecho);
+  URGCWrapper(const int serial_baud, const std::string& serial_port, bool& using_intensity, bool& using_multiecho, bool& synchronize_time);
 
   ~URGCWrapper();
 
@@ -166,7 +166,7 @@ public:
   bool getDL00Status(UrgDetectionReport& report);
 
 private:
-  void initialize(bool& using_intensity, bool& using_multiecho);
+  void initialize(bool& using_intensity, bool& using_multiecho, bool& synchronize_time);
 
   bool isIntensitySupported();
 
@@ -177,6 +177,14 @@ private:
   ros::Duration getNativeClockOffset(size_t num_measurements);
 
   ros::Duration getTimeStampOffset(size_t num_measurements);
+
+  /**
+   * @brief Get synchronized time stamp using hardware clock
+   * @param time_stamp The current hardware time stamp.
+   * @param system_time_stamp The current system time stamp.
+   * @returns ros::Time stamp representing synchronized time
+   */
+  ros::Time getSynchronizedTime(long time_stamp, long long system_time_stamp);
 
   /**
    * @brief Set the Hokuyo URG-04LX from SCIP 1.1 mode to SCIP 2.0 mode.
@@ -218,6 +226,14 @@ private:
 
   ros::Duration system_latency_;
   ros::Duration user_latency_;
+
+  // used for clock synchronziation
+  bool synchronize_time_;
+  double hardware_clock_;
+  long last_hardware_time_stamp_;
+  double hardware_clock_adj_;
+  const double adj_alpha_ = .01;
+  uint64_t adj_count_;
 
   std::string ip_address_;
   int ip_port_;

--- a/include/urg_node/urg_node_driver.h
+++ b/include/urg_node/urg_node_driver.h
@@ -116,6 +116,7 @@ private:
   std::string serial_port_;
   int serial_baud_;
   bool calibrate_time_;
+  bool synchronize_time_;
   bool publish_intensity_;
   bool publish_multiecho_;
   int error_limit_;

--- a/src/getID.cpp
+++ b/src/getID.cpp
@@ -106,6 +106,7 @@ main(int argc, char** argv)
 
   bool publish_intensity = false;
   bool publish_multiecho = false;
+  bool synchronize_time = false;
   int serial_baud = 115200;
   int ip_port = 10940;
   std::string ip_address = "";
@@ -139,11 +140,11 @@ main(int argc, char** argv)
     {
       if (ip_address != "")
       {
-        urg_.reset(new urg_node::URGCWrapper(ip_address, ip_port, publish_intensity, publish_multiecho));
+        urg_.reset(new urg_node::URGCWrapper(ip_address, ip_port, publish_intensity, publish_multiecho, synchronize_time));
       }
       else
       {
-        urg_.reset(new urg_node::URGCWrapper(serial_baud, serial_port, publish_intensity, publish_multiecho));
+        urg_.reset(new urg_node::URGCWrapper(serial_baud, serial_port, publish_intensity, publish_multiecho, synchronize_time));
       }
       std::string device_id = urg_->getDeviceID();
       if (verbose)

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -41,7 +41,7 @@
 namespace urg_node
 {
 
-URGCWrapper::URGCWrapper(const std::string& ip_address, const int ip_port, bool& using_intensity, bool& using_multiecho)
+URGCWrapper::URGCWrapper(const std::string& ip_address, const int ip_port, bool& using_intensity, bool& using_multiecho, bool& synchronize_time)
 {
   // Store for comprehensive diagnostics
   ip_address_ = ip_address;
@@ -63,11 +63,11 @@ URGCWrapper::URGCWrapper(const std::string& ip_address, const int ip_port, bool&
     throw std::runtime_error(ss.str());
   }
 
-  initialize(using_intensity, using_multiecho);
+  initialize(using_intensity, using_multiecho, synchronize_time);
 }
 
 URGCWrapper::URGCWrapper(const int serial_baud, const std::string& serial_port,
-    bool& using_intensity, bool& using_multiecho)
+    bool& using_intensity, bool& using_multiecho, bool& synchronize_time)
 {
   // Store for comprehensive diagnostics
   serial_baud_ = serial_baud;
@@ -90,10 +90,10 @@ URGCWrapper::URGCWrapper(const int serial_baud, const std::string& serial_port,
     throw std::runtime_error(ss.str());
   }
 
-  initialize(using_intensity, using_multiecho);
+  initialize(using_intensity, using_multiecho, synchronize_time);
 }
 
-void URGCWrapper::initialize(bool& using_intensity, bool& using_multiecho)
+void URGCWrapper::initialize(bool& using_intensity, bool& using_multiecho, bool& synchronize_time)
 {
   int urg_data_size = urg_max_data_size(&urg_);
   // urg_max_data_size can return a negative, error code value. Resizing based on this value will fail.
@@ -131,6 +131,12 @@ void URGCWrapper::initialize(bool& using_intensity, bool& using_multiecho)
   last_step_ = 0;
   cluster_ = 1;
   skip_ = 0;
+
+  synchronize_time_ = synchronize_time;
+  hardware_clock_ = 0.0;
+  last_hardware_time_stamp_ = 0;
+  hardware_clock_adj_ = 0.0;
+  adj_count_ = 0;
 
   if (using_intensity)
   {
@@ -226,7 +232,14 @@ bool URGCWrapper::grabScan(const sensor_msgs::LaserScanPtr& msg)
   }
 
   // Fill scan
-  msg->header.stamp.fromNSec((uint64_t)system_time_stamp);
+  if (synchronize_time_)
+  {
+    msg->header.stamp = getSynchronizedTime(time_stamp, system_time_stamp);
+  }
+  else
+  {
+    msg->header.stamp.fromNSec((uint64_t)system_time_stamp);
+  }
   msg->header.stamp = msg->header.stamp + system_latency_ + user_latency_ + getAngularTimeOffset();
   msg->ranges.resize(num_beams);
   if (use_intensity_)
@@ -1033,5 +1046,39 @@ ros::Duration URGCWrapper::getTimeStampOffset(size_t num_measurements)
   // Sort vector using nth_element (partially sorts up to the median index)
   std::nth_element(time_offsets.begin(), time_offsets.begin() + time_offsets.size() / 2, time_offsets.end());
   return time_offsets[time_offsets.size() / 2];
+}
+
+ros::Time URGCWrapper::getSynchronizedTime(long time_stamp, long long system_time_stamp)
+{
+  ros::Time stamp;
+  stamp.fromNSec((uint64_t)system_time_stamp);
+
+  const uint32_t t1 = static_cast<uint32_t>(time_stamp);
+  const uint32_t t0 = static_cast<uint32_t>(last_hardware_time_stamp_);
+  // hokuyo uses a 24-bit counter, so mask out irrelevant bits
+  const uint32_t mask = 0x00ffffff;
+  double delta = static_cast<double>(mask&(t1-t0))/1000.0;
+  ROS_INFO("delta: %f", delta);
+  hardware_clock_ += delta;
+  double cur_adj = stamp.toSec() - hardware_clock_;
+  if (adj_count_>0)
+  {
+    hardware_clock_adj_=adj_alpha_*cur_adj+(1.0-adj_alpha_)*hardware_clock_adj_;
+  }
+  else
+  {
+    //initialize
+    hardware_clock_adj_=cur_adj;
+  }
+  adj_count_++;
+  last_hardware_time_stamp_ = time_stamp;
+
+  // Once hardware clock is synchronized, use it. Otherwise just return the
+  // input system_time_stamp as ros::Time.
+  if (adj_count_>100)
+  {
+    stamp.fromSec(hardware_clock_+hardware_clock_adj_);
+  }
+  return stamp;
 }
 }  // namespace urg_node

--- a/src/urg_node_driver.cpp
+++ b/src/urg_node_driver.cpp
@@ -74,6 +74,7 @@ void UrgNode::initSetup()
   pnh_.param<std::string>("serial_port", serial_port_, "/dev/ttyACM0");
   pnh_.param<int>("serial_baud", serial_baud_, 115200);
   pnh_.param<bool>("calibrate_time", calibrate_time_, false);
+  pnh_.param<bool>("synchronize_time", synchronize_time_, false);
   pnh_.param<bool>("publish_intensity", publish_intensity_, true);
   pnh_.param<bool>("publish_multiecho", publish_multiecho_, false);
   pnh_.param<int>("error_limit", error_limit_, 4);
@@ -366,11 +367,11 @@ bool UrgNode::connect()
     urg_.reset();  // Clear any previous connections();
     if (!ip_address_.empty())
     {
-      urg_.reset(new urg_node::URGCWrapper(ip_address_, ip_port_, publish_intensity_, publish_multiecho_));
+      urg_.reset(new urg_node::URGCWrapper(ip_address_, ip_port_, publish_intensity_, publish_multiecho_, synchronize_time_));
     }
     else
     {
-      urg_.reset(new urg_node::URGCWrapper(serial_baud_, serial_port_, publish_intensity_, publish_multiecho_));
+      urg_.reset(new urg_node::URGCWrapper(serial_baud_, serial_port_, publish_intensity_, publish_multiecho_, synchronize_time_));
     }
 
     std::stringstream ss;


### PR DESCRIPTION
Remove jitter from the system clock by synchronizing it to the change
in hardware time stamps. This does not synchrnoize it in an absolute
sense (i.e., doesn't remove system latench). However, coupled with
calibrating system latency, this results in a stable, accurate clock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/urg_node/1)
<!-- Reviewable:end -->
